### PR TITLE
use absolute path to compare watched files 

### DIFF
--- a/entangled/commands/watch.py
+++ b/entangled/commands/watch.py
@@ -24,15 +24,15 @@ class EventHandler(FileSystemEventHandler):
             return
         config.read()
         path = Path(event.src_path)
-        if path.is_relative_to(Path("./.entangled")):
+        if path.absolute().is_relative_to(Path("./.entangled").absolute()):
             return
-        if any(path.is_relative_to(p.absolute()) for p in self.watched):
-            os.sync()
+        if any(path.absolute().is_relative_to(p.absolute()) for p in self.watched):
             sync()
+            os.sync()
         self.update_watched()
 
 
-def _watch(_stop_event: Optional[Event] = None):
+def _watch(_stop_event: Optional[Event] = None, _start_event: Optional[Event] = None):
     """Keep a loop running, watching for changes. This interface is separated
     from the CLI one, so that it can be tested using threading instead of
     subprocess."""
@@ -46,6 +46,9 @@ def _watch(_stop_event: Optional[Event] = None):
     observer = Observer()
     observer.schedule(event_handler, ".", recursive=True)
     observer.start()
+
+    if _start_event:
+        _start_event.set()
 
     try:
         while observer.is_alive() and not stop():

--- a/entangled/commands/watch.py
+++ b/entangled/commands/watch.py
@@ -2,6 +2,7 @@ from typing import Optional
 from pathlib import Path
 from itertools import chain
 from threading import Event
+import os
 
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, FileSystemEvent
@@ -25,7 +26,8 @@ class EventHandler(FileSystemEventHandler):
         path = Path(event.src_path)
         if path.is_relative_to(Path("./.entangled")):
             return
-        if any(path.is_relative_to(p) for p in self.watched):
+        if any(path.is_relative_to(p.absolute()) for p in self.watched):
+            os.sync()
             sync()
         self.update_watched()
 

--- a/test/test_daemon.py
+++ b/test/test_daemon.py
@@ -36,8 +36,11 @@ def test_daemon(tmp_path: Path):
         try:
             configure(debug=True)
             stop = threading.Event()
-            t = threading.Thread(target=_watch, args=(stop,))
+            start = threading.Event()
+            t = threading.Thread(target=_watch, args=(stop, start))
             t.start()
+            # Wait for watch to boot up
+            start.wait()
             Path("main.md").write_text(
                 "``` {.scheme file=hello.scm}\n" '(display "hello") (newline)\n' "```\n"
             )

--- a/test/test_daemon.py
+++ b/test/test_daemon.py
@@ -9,6 +9,27 @@ from entangled.main import configure
 
 from contextlib import chdir
 
+def wait_for_file(filename, timeout=5):
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        if os.path.exists(filename):
+            return True
+        time.sleep(0.1)  
+
+    return False
+
+def wait_for_stat_diff(md_stat, filename, timeout=5):
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        md_stat2 = stat(Path(filename))
+        if(md_stat != md_stat2):
+            return True
+        time.sleep(0.1)  
+
+    return False
+
 def test_daemon(tmp_path: Path):
     config.read()
     with chdir(tmp_path):
@@ -20,15 +41,16 @@ def test_daemon(tmp_path: Path):
             Path("main.md").write_text(
                 "``` {.scheme file=hello.scm}\n" '(display "hello") (newline)\n' "```\n"
             )
-            time.sleep(0.1)
+            wait_for_file("main.md")
             md_stat1 = stat(Path("main.md"))
+            wait_for_file("hello.scm")
             assert Path("hello.scm").exists()
 
             lines = Path("hello.scm").read_text().splitlines()
             goodbye = '(display "goodbye") (newline)'
             lines.insert(2, goodbye)
             Path("hello.scm").write_text("\n".join(lines))
-            time.sleep(0.2)
+            wait_for_stat_diff(md_stat1, "main.md")
             md_stat2 = stat(Path("main.md"))
             assert md_stat1 != md_stat2
             assert md_stat1 < md_stat2
@@ -39,8 +61,8 @@ def test_daemon(tmp_path: Path):
 
             lines[0] = "``` {.scheme file=foo.scm}"
             Path("main.md").write_text("\n".join(lines))
-            time.sleep(0.1)
 
+            wait_for_file("foo.scm")
             assert not Path("hello.scm").exists()
             assert Path("foo.scm").exists()
 


### PR DESCRIPTION
test_daemon test was failing on mac due to comparing tmp_path create by pytest. A fix uses absolute path to compare watched files and eventual sync in test_daemon.