### PR TITLE
add `entangled new` command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/templates/mkdocs"]
+	path = test/templates/mkdocs
+	url = git@github.com:entangled/template-mkdocs

--- a/entangled/commands/__init__.py
+++ b/entangled/commands/__init__.py
@@ -1,8 +1,16 @@
-from .tangle import tangle
+from .new import new
+from .status import status
 from .stitch import stitch
 from .sync import sync
+from .tangle import tangle
 from .watch import watch
-from .status import status
 
 
-__all__ = ["tangle", "stitch", "sync", "watch", "status"]
+__all__ = [
+        "new",
+        "status"
+        "stitch",
+        "sync",
+        "tangle",
+        "watch",
+        ]

--- a/entangled/commands/new.py
+++ b/entangled/commands/new.py
@@ -1,0 +1,204 @@
+from typing import Optional, Union
+
+import argh  # type: ignore
+import argparse
+import logging
+import traceback
+
+from copier import run_copy  # type: ignore
+from copier.errors import CopierError, UnsafeTemplateError  # type: ignore
+from pathlib import Path
+from rich.console import Console
+from rich.table import Table
+
+from ..config.templates import templates as AVAILABLE_TEMPLATES
+from ..config.templates import Template
+from ..errors.user import HelpfulUserError
+
+description = """Create a new entangled project from a template.
+
+You can choose either one of the official supported, built-in templates (see:
+entangled new -l), or any other template that copier supports, see:
+https://copier.readthedocs.io/en/stable/reference/vcs/#copier.vcs.get_repo"""
+
+
+def print_available_templates() -> None:
+    table: Table = Table(title="Official Templates")
+    table.add_column("Handle")
+    table.add_column("Name")
+    table.add_column("URL")
+    table.add_column("Prerequisites")
+    table.add_column("Description")
+
+    t: Template
+    for t in AVAILABLE_TEMPLATES:
+        table.add_row(t.handle, t.name, t.url, t.prerequisites, t.description)
+
+    console: Console = Console()
+    console.print(table)
+    print("\nUsage: entangled new [handle] [project_path]\n")
+
+
+def print_help() -> None:
+    """Print help as if '-h' was used.
+
+    For this we first have to create a parser and attach this `new` function
+    to it. Then we have a parser object that we can `print_help()` from.
+    """
+    parser = argparse.ArgumentParser()
+    argh.add_commands(parser, [new])
+    argh.utils.get_subparsers(parser).choices["new"].print_help()
+
+
+@argh.arg(
+    "-a",
+    "--answers-file",
+    help="Update using this path (relative to [project_path]) to find the answers file for `copier`",
+)
+@argh.arg(
+    "-d",
+    "--data",
+    help='"VARIABLE1=VALUE1;VARIABLE1=VALUE2" Make VARIABLEs available as VALUEs when rendering the template; make sure to use quotation marks for multiple variables/values',
+)
+@argh.arg(
+    "-D",
+    "--defaults",
+    help="Use default answers to questions, which might be null if not specified; overwrites when combined with -d!",
+)
+@argh.arg(
+    "-p",
+    "--pretend",
+    help="Run but do not make any changes",
+)
+@argh.arg(
+    "-o",
+    "--overwrite",
+    help="Overwrite files that already exist, without asking.",
+)
+@argh.arg(
+    "-l",
+    "--list-templates",
+    help="List all official templates and exit",
+)
+@argh.arg(
+    "-t",
+    "--trust",
+    help='Allow templates with unsafe features (Jinja extensions, migrations, tasks); "True" for officially supported templates',
+)
+@argh.arg(
+    "template",
+    default=None,
+    nargs="?",
+    help="Template handle or URL; initialize a new project from this template",
+)
+@argh.arg(
+    "project_path",
+    default=None,
+    nargs="?",
+    help="Initialize a new project at this path",
+)
+def new(
+    template: Optional[str],
+    project_path: Optional[Path],
+    answers_file: Optional[str] = None,
+    data: str = "",
+    defaults: bool = False,
+    pretend: bool = False,
+    overwrite: bool = False,
+    list_templates: bool = False,
+    trust: bool = False,
+) -> None:
+    """Create a new entangled project from a template."""
+
+    if list_templates:
+        print_available_templates()
+        return
+
+    if not template or not project_path:
+        raise HelpfulUserError(
+            "Please supply both a [template] and a [project_path].\n", print_help
+        )
+
+    copy_this_template: Optional[str] = template
+    trust_this_template: bool = trust
+
+    # Use an officially supported template, if available, and trust it
+    # If no template is found, treat the "template" var as URL or path for copier
+    template_option: Template
+    for template_option in AVAILABLE_TEMPLATES:
+        if template == template_option.handle:
+            trust_this_template = True
+            copy_this_template = template_option.url
+            break
+
+    data_dict: dict = {}
+    if data:
+        try:
+            for d in data.split(";"):
+                if d:  # Allow for leading or trailing ";"
+                    key, value = d.split("=")
+                    data_dict[key] = value
+        except ValueError:
+            raise HelpfulUserError(
+                "Invalid syntax for `-d/--data`. Please make sure "
+                "to closely follow the example below.\n",
+                print_help,
+            )
+
+    try:
+        run_copy(
+            src_path=copy_this_template,
+            dst_path=project_path,
+            answers_file=answers_file,
+            data=data_dict,
+            defaults=defaults,
+            pretend=pretend,
+            overwrite=overwrite,
+            unsafe=trust_this_template,
+        )
+    # Suggest users to use --trust if needed
+    except UnsafeTemplateError:
+        raise HelpfulUserError(
+            "Template uses potentially unsafe features. If you trust this template, "
+            "consider adding the `--trust` option when running `entangled new`."
+        )
+    # If the [project_path] does not exist, `copier` catches a FileNotFoundError
+    # and tries to create it. When this fails due to a PermissionError, the
+    # FileNotFoundError is re-raised, but it's not the reason the operation
+    # failed. We have to check for the reason for the FileNotFoundError to see
+    # where it went wrong.
+    except FileNotFoundError as e:
+        if e.__context__.__class__ == PermissionError:
+            raise HelpfulUserError(
+                "A folder in [project_path] is not writable, please "
+                "review its permissions."
+            )
+        else:
+            raise HelpfulUserError(e.__str__())
+    except PermissionError:
+        raise HelpfulUserError(
+            "A folder in [project_path] is not writable, please "
+            "review its permissions."
+        )
+    # Display generic copier errors without stacktrace
+    except Exception as e:
+        if "Local template must be a directory" in e.__str__():
+            raise HelpfulUserError(
+                f'Template "{template}" not found. Please supply a valid path or '
+                "URL,\nor use one of the officially supported ones from the "
+                "following list:\n",
+                print_available_templates,
+            )
+        elif "Question " in e.__str__():
+            raise HelpfulUserError(
+                "Template data missing.\nPlease supply a valid answers file "
+                "with a path `relative` to the [project_path], or valid data "
+                "with -d/--data.\n",
+                print_help,
+            )
+        else:
+            raise HelpfulUserError(
+                f"The library `copier` gave an error:\n\n{e.__str__()}.\n\nIf you "
+                "are trying to develop a template, please use `copier` directly, "
+                "see https://copier.readthedocs.io .",
+            )

--- a/entangled/config/templates.py
+++ b/entangled/config/templates.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Template:
+    """Officially supported templates. Templates are pulled from external GitHub
+    repositories: `entangled new <template name>`. These templates are the ones
+    we officially support. Other templates can be used with valid copier URL
+    notation, like: `entangled new gh:<url>`. See
+    https://copier.readthedocs.io/en/stable/reference/vcs/#copier.vcs.get_repo
+    for valid URL examples.
+    """
+
+    handle: str
+    name: str
+    url: str
+    prerequisites: str
+    description: str
+
+
+templates: list[Template] = [
+    Template(
+        "mkdocs",
+        "MkDocs",
+        "gh:entangled/template-mkdocs",
+        "python, mkdocs",
+        "Fast, simple project documentation for Python",
+    ),
+]

--- a/entangled/errors/user.py
+++ b/entangled/errors/user.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from textwrap import wrap
+from typing import Callable
 
 from ..document import TextLocation
 
@@ -7,6 +8,19 @@ from ..document import TextLocation
 class UserError(Exception):
     def __str__(self):
         return "Unknown user error."
+
+
+@dataclass
+class HelpfulUserError(UserError):
+    """Raise a user error and supply an optional function `func` for context.
+
+    Make sure to also execute e.func() in your error handling."""
+
+    msg: str
+    func: Callable = lambda: None
+
+    def __str__(self):
+        return f"error: {self.msg}"
 
 
 @dataclass

--- a/entangled/main.py
+++ b/entangled/main.py
@@ -12,9 +12,9 @@ except ImportError:
     WITH_RICH = False
 
 
-from .commands import tangle, stitch, sync, watch, status
+from .commands import new, status, stitch, sync, tangle, watch
 from .errors.internal import bug_contact
-from .errors.user import UserError
+from .errors.user import HelpfulUserError, UserError
 from .version import __version__
 
 
@@ -57,7 +57,7 @@ def cli():
         parser.add_argument(
             "-v", "--version", action="store_true", help="show version number"
         )
-        argh.add_commands(parser, [tangle, stitch, sync, watch, status])
+        argh.add_commands(parser, [new, status, stitch, sync, tangle, watch])
         args = parser.parse_args()
 
         if args.version:
@@ -69,8 +69,12 @@ def cli():
     except KeyboardInterrupt:
         logging.info("Goodbye")
         sys.exit(0)
+    except HelpfulUserError as e:
+        logging.error(e, exc_info=False)
+        e.func()
+        sys.exit(0)
     except UserError as e:
-        logging.info(str(e))
+        logging.error(e, exc_info=False)
         sys.exit(0)
     except Exception as e:
         logging.error(str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ filelock = "^3.12.0"      # file lock for json db
 argh = "^0.28.1"
 rich = "^13.3.5"
 tomlkit = "^0.12.1"
+copier = "^8.3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/test/templates/minimal/copier.yml
+++ b/test/templates/minimal/copier.yml
@@ -1,0 +1,9 @@
+_subdirectory: template
+
+_message_after_copy: |
+    Your minimal project has been generated.
+
+project_name:
+    type: str
+    help: What is your project name?
+

--- a/test/templates/minimal/template/README.md
+++ b/test/templates/minimal/template/README.md
@@ -1,0 +1,2 @@
+# Minimal Template for Testing
+[![Entangled badge](https://img.shields.io/badge/entangled-Use%20the%20source!-%2300aeff)](https://entangled.github.io/)

--- a/test/templates/minimal/template/{{_copier_conf.answers_file}}.jinja
+++ b/test/templates/minimal/template/{{_copier_conf.answers_file}}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+{{ _copier_answers|to_nice_yaml -}}

--- a/test/templates/minimal_unsafe/copier.yml
+++ b/test/templates/minimal_unsafe/copier.yml
@@ -1,0 +1,12 @@
+_subdirectory: template
+
+_tasks:
+    - "git init"
+
+_message_after_copy: |
+    Your minimal project has been generated.
+
+project_name:
+    type: str
+    help: What is your project name?
+

--- a/test/templates/minimal_unsafe/template/README.md
+++ b/test/templates/minimal_unsafe/template/README.md
@@ -1,0 +1,2 @@
+# Minimal Template for Testing
+[![Entangled badge](https://img.shields.io/badge/entangled-Use%20the%20source!-%2300aeff)](https://entangled.github.io/)

--- a/test/templates/minimal_unsafe/template/{{_copier_conf.answers_file}}.jinja
+++ b/test/templates/minimal_unsafe/template/{{_copier_conf.answers_file}}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+{{ _copier_answers|to_nice_yaml -}}

--- a/test/test_new.py
+++ b/test/test_new.py
@@ -1,0 +1,113 @@
+import pytest
+import unittest
+
+from os.path import join
+from typing import IO
+
+from entangled.commands.new import new
+from entangled.config.templates import Template, templates
+from entangled.errors.user import HelpfulUserError
+
+
+def test_print_available_templates() -> None:
+    """Test if official template settings can be read"""
+    new(template="", project_path="", list_templates=True)
+
+
+def test_pretend_template_copy() -> None:
+    """Test dry run"""
+    new(
+        template="./test/templates/minimal",
+        project_path="_",
+        data="project_name=my_project",
+        defaults=True,
+        pretend=True,
+    )
+
+
+def test_multiple_data() -> None:
+    """Test `-d/--data` syntax"""
+    new(
+        template="./test/templates/minimal",
+        project_path="_",
+        data="project_name=my_project;key=value;",
+        defaults=True,
+        pretend=True,
+    )
+
+
+def test_minimal_template_copy(tmp_path) -> None:
+    """Test if initializing a new project with a minimal template works"""
+    new(
+        template="./test/templates/minimal",
+        project_path=str(tmp_path),
+        data="project_name=my_project",
+        defaults=True,
+    )
+
+
+def test_untrusted_template_pass(tmp_path) -> None:
+    """Test if initializing a new project with an untrusted template fails"""
+    new(
+        template="./test/templates/minimal_unsafe",
+        project_path=str(tmp_path),
+        data="project_name=my_project",
+        defaults=True,
+        trust=True,
+    )
+
+
+def test_untrusted_template_fail(tmp_path) -> None:
+    """Test if initializing a new project with an untrusted template fails"""
+    with pytest.raises(HelpfulUserError, match="Template uses potentially unsafe"):
+        new(
+            template="./test/templates/minimal_unsafe",
+            project_path=str(tmp_path),
+            data="project_name=my_project",
+            defaults=True,
+        )
+
+
+def test_overwrite_template(tmp_path) -> None:
+    """Force overwrite a project with different data"""
+    new(
+        template="./test/templates/minimal",
+        project_path=str(tmp_path),
+        data="project_name=my_project",
+        defaults=True,
+    )
+    new(
+        template="./test/templates/minimal",
+        project_path=str(tmp_path),
+        data="project_name=my_other_project",
+        defaults=True,
+        overwrite=True,
+    )
+
+
+def test_default_answers_file(tmp_path) -> None:
+    """Test pre-supplying answers to template questions"""
+    default_answers_file: str = join(tmp_path, ".copier-answers.yml")
+    f: IO
+    with open(default_answers_file, "w") as f:
+        f.write("project_name: default_project")
+    new(
+        template="./test/templates/minimal",
+        project_path=str(tmp_path),
+        defaults=True,
+    )
+
+
+def test_custom_answers_file(tmp_path) -> None:
+    """Test pre-supplying answers to template questions"""
+    my_answers_file_name = ".my-answers.yml"
+    my_answers_file: str = join(tmp_path, my_answers_file_name)
+    f: IO
+    with open(my_answers_file, "w") as f:
+        f.write("project_name: my_project")
+    new(
+        template="./test/templates/minimal",
+        project_path=str(tmp_path),
+        answers_file=my_answers_file_name,
+        defaults=True,
+    )


### PR DESCRIPTION
Start new projects from a template directly with `entangled`.

```
usage: entangled new [-h] [-a ANSWERS_FILE] [-d DATA] [-D] [-p] [-o] [-l] [-t] [template] [project_path]

Create a new entangled project from a template.

positional arguments:
  template              Template handle or URL; initialize a new project from this template (default: -)
  project_path          Initialize a new project at this path (default: -)

options:
  -h, --help            show this help message and exit
  -a ANSWERS_FILE, --answers-file ANSWERS_FILE
                        Update using this path (relative to [project_path]) to find the answers file for `copier`
                        (default: -)
  -d DATA, --data DATA  "VARIABLE1=VALUE1;VARIABLE1=VALUE2" Make VARIABLEs available as VALUEs when rendering the
                        template; make sure to use quotation marks for multiple variables/values (default: '')
  -D, --defaults        Use default answers to questions, which might be null if not specified; overwrites when combined
                        with -d! (default: False)
  -p, --pretend         Run but do not make any changes (default: False)
  -o, --overwrite       Overwrite files that already exist, without asking. (default: False)
  -l, --list-templates  List all official templates and exit (default: False)
  -t, --trust           Allow templates with unsafe features (Jinja extensions, migrations, tasks); "True" for
                        officially supported templates (default: False)


```

Currently available official templates:
```
                                                Official Templates                                                 
┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Handle ┃ Name   ┃ URL                          ┃ Prerequisites  ┃ Description                                   ┃
┡━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ mkdocs │ MkDocs │ gh:entangled/template-mkdocs │ python, mkdocs │ Fast, simple project documentation for Python │
└────────┴────────┴──────────────────────────────┴────────────────┴───────────────────────────────────────────────┘

```

TODO:
- [X] Tests
- [ ] Review template description and prerequisites
- [ ] More templates?
- [ ] Template caching

closes https://github.com/entangled/entangled.py/issues/11