### PR TITLE
Feature/16/reduce conflicting changes

### DIFF
--- a/entangled/commands/stitch.py
+++ b/entangled/commands/stitch.py
@@ -28,7 +28,9 @@ def stitch_markdown(reference_map: ReferenceMap, content: list[Content]) -> str:
 @argh.arg("-s", "--show", help="only show, don't act")
 def stitch(*, force: bool = False, show: bool = False):
     """Stitch code changes back into the Markdown"""
-    input_file_list = list(chain.from_iterable(map(Path(".").glob, config.watch_list)))
+    include_file_list = chain.from_iterable(map(Path(".").glob, config.watch_list))
+    exclude_file_list = list(chain.from_iterable(map(Path(".").glob, config.ignore_list)))
+    input_file_list = [path for path in include_file_list if not path in exclude_file_list]
 
     if show:
         mode = TransactionMode.SHOW

--- a/entangled/commands/sync.py
+++ b/entangled/commands/sync.py
@@ -16,7 +16,9 @@ def _stitch_then_tangle():
 
 
 def sync_action() -> Optional[Callable[[], None]]:
-    input_file_list = list(chain.from_iterable(map(Path(".").glob, config.watch_list)))
+    include_file_list = chain.from_iterable(map(Path(".").glob, config.watch_list))
+    exclude_file_list = list(chain.from_iterable(map(Path(".").glob, config.ignore_list)))
+    input_file_list = [path for path in include_file_list if not path in exclude_file_list]
 
     with file_db(readonly=True) as db:
         changed = set(db.changed())

--- a/entangled/commands/tangle.py
+++ b/entangled/commands/tangle.py
@@ -29,7 +29,10 @@ def tangle(*, annotate: Optional[str] = None, force: bool = False, show: bool = 
     else:
         annotation_method = AnnotationMethod[annotate.upper()]
 
-    input_file_list = chain.from_iterable(map(Path(".").glob, config.watch_list))
+    include_file_list = chain.from_iterable(map(Path(".").glob, config.watch_list))
+    exclude_file_list = list(chain.from_iterable(map(Path(".").glob, config.ignore_list)))
+    input_file_list = [path for path in include_file_list if not path in exclude_file_list]
+
     refs = ReferenceMap()
     hooks = get_hooks()
 

--- a/entangled/config/__init__.py
+++ b/entangled/config/__init__.py
@@ -63,6 +63,7 @@ class Config(threading.local):
     languages: list[Language] = field(default_factory=list)
     markers: Markers = field(default_factory=lambda: copy(markers))
     watch_list: list[str] = field(default_factory=lambda: ["**/*.md"])
+    ignore_list: list[str] = field(default_factory=lambda: ["**/README.md"])
     annotation_format: Optional[str] = None
     annotation: AnnotationMethod = AnnotationMethod.STANDARD
     use_line_directives: bool = False

--- a/entangled/filedb.py
+++ b/entangled/filedb.py
@@ -159,6 +159,8 @@ class FileDB:
                     "File `%s` in DB doesn't exist. Removing entry from DB.", path
                 )
                 del db[path]
+            if len(undead) > 0:
+                db.write()
             return db
 
         FileDB.path().parent.mkdir(parents=True, exist_ok=True)

--- a/entangled/filedb.py
+++ b/entangled/filedb.py
@@ -30,13 +30,16 @@ class FileStat:
     deps: Optional[list[Path]]
     modified: datetime
     hexdigest: str
+    size: int
 
     @staticmethod
     def from_path(path: Path, deps: Optional[list[Path]]):
         stat = os.stat(path)
+        size = stat.st_size
         with open(path, "r") as f:
             digest = hexdigest(f.read())
-        return FileStat(path, deps, datetime.fromtimestamp(stat.st_mtime), digest)
+
+        return FileStat(path, deps, datetime.fromtimestamp(stat.st_mtime), digest, size)
 
     def __lt__(self, other: FileStat) -> bool:
         return self.modified < other.modified
@@ -51,6 +54,7 @@ class FileStat:
             None if data["deps"] is None else [Path(d) for d in data["deps"]],
             datetime.fromisoformat(data["modified"]),
             data["hexdigest"],
+            data["size"]
         )
 
     def to_json(self):
@@ -59,6 +63,7 @@ class FileStat:
             "deps": None if self.deps is None else [str(p) for p in self.deps],
             "modified": self.modified.isoformat(),
             "hexdigest": self.hexdigest,
+            "size": self.size
         }
 
 

--- a/entangled/status.py
+++ b/entangled/status.py
@@ -16,7 +16,9 @@ def find_watch_dirs():
 
 def list_input_files():
     """List all input files."""
-    return chain.from_iterable(map(Path(".").glob, config.watch_list))
+    include_file_list = chain.from_iterable(map(Path(".").glob, config.watch_list))
+    exclude_file_list = list(chain.from_iterable(map(Path(".").glob, config.ignore_list)))
+    return [path for path in include_file_list if not path in exclude_file_list]
 
 
 def list_dependent_files():

--- a/entangled/transaction.py
+++ b/entangled/transaction.py
@@ -43,6 +43,7 @@ class Create(Action):
     def conflict(self, _) -> Optional[str]:
         if self.target.exists():
             # Check if file contents are the same as what we want to write or is empty
+            # then it is safe to take ownership.
             md_stat = stat(self.target)
             fileHexdigest = md_stat.hexdigest
             contentHexdigest = hexdigest(self.content)
@@ -70,6 +71,9 @@ class Write(Action):
 
     def conflict(self, db: FileDB) -> Optional[str]:
         st = stat(self.target)
+        # If content remained the same then we resolve the conflict
+        if st.hexdigest == db[self.target].hexdigest:
+            return None
         if st != db[self.target]:
             return f"`{self.target}` seems to have changed outside the control of Entangled"
         if self.sources:

--- a/entangled/transaction.py
+++ b/entangled/transaction.py
@@ -71,9 +71,6 @@ class Write(Action):
 
     def conflict(self, db: FileDB) -> Optional[str]:
         st = stat(self.target)
-        # If content remained the same then we resolve the conflict
-        if st.hexdigest == db[self.target].hexdigest:
-            return None
         if st != db[self.target]:
             return f"`{self.target}` seems to have changed outside the control of Entangled"
         if self.sources:
@@ -96,9 +93,7 @@ class Delete(Action):
     def conflict(self, db: FileDB) -> Optional[str]:
         st = stat(self.target)
         if st != db[self.target]:
-            return (
-                f"{self.target} seems to have changed outside the control of Entangled"
-            )
+            return f"{self.target} seems to have changed outside the control of Entangled"
         return None
 
     def run(self, db: FileDB):

--- a/entangled/transaction.py
+++ b/entangled/transaction.py
@@ -14,7 +14,7 @@ except ImportError:
     WITH_RICH = False
 
 from .utility import cat_maybes
-from .filedb import FileDB, stat, file_db
+from .filedb import FileDB, stat, file_db, hexdigest
 from .errors.internal import InternalError
 
 
@@ -41,6 +41,12 @@ class Create(Action):
 
     def conflict(self, _) -> Optional[str]:
         if self.target.exists():
+            # Check if file contents are the same as what we want to write or is empty
+            md_stat = stat(self.target)
+            fileHexdigest = md_stat.hexdigest
+            contentHexdigest = hexdigest(self.content)
+            if (contentHexdigest == fileHexdigest) or (md_stat.size == 0):
+                return None
             return f"{self.target} already exists and is not managed by Entangled"
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ filelock = "^3.12.0"      # file lock for json db
 argh = "^0.28.1"
 rich = "^13.3.5"
 tomlkit = "^0.12.1"
-atomicwrites = "^1.4.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ filelock = "^3.12.0"      # file lock for json db
 argh = "^0.28.1"
 rich = "^13.3.5"
 tomlkit = "^0.12.1"
+atomicwrites = "^1.4.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/test/test_ignore_list.py
+++ b/test/test_ignore_list.py
@@ -1,0 +1,63 @@
+from entangled.config import config
+from entangled.status import find_watch_dirs, list_input_files
+from contextlib import chdir
+from entangled.commands.tangle import tangle
+from pathlib import Path
+
+readme_md = """
+# README
+```{.python file=src/test.py}
+print("test")
+```
+"""
+
+index_md_1 = """
+# Test
+
+``` {.c file=src/test.c}
+#include <stdio.h>
+int main() { printf("Hello, World!\\n"); return 0; }
+```
+"""
+
+index_md_2 = """
+``` {.makefile file=Makefile}
+.RECIPEPREFIX = >
+
+%.o: %.c
+> gcc -c $< -o $@
+
+hello: test.o
+> gcc $^ -o $@
+```
+"""
+
+data_md = """
+Don't tangle me!
+```{.python file=src/test2.py}
+print("test2")
+```
+"""
+
+def list_files_recursive(directory):
+    for root, _, files in os.walk(directory):
+        for file in files:
+            file_path = os.path.join(root, file)
+            print(file_path)
+
+def test_watch_dirs(tmp_path):
+    with chdir(tmp_path):
+        Path("./docs").mkdir()
+        Path("./docs/data").mkdir()
+        Path("./docs/index.md").write_text(index_md_1)
+        Path("./docs/data/data.md").write_text(data_md)
+        Path("./docs/README.md").write_text(readme_md)
+        with config(watch_list=["**/*.md"], ignore_list=["**/data/*", "**/README.md"]):
+            tangle()
+            # data.md and README.md should not be entangled cause they are part
+            # of the ignore list while index.md should be so test2.py, test.py 
+            # should not be created while test.c should be created.
+            assert not Path.exists(Path("./src/test2.py"))
+            assert not Path.exists(Path("./src/test.py"))
+            assert Path.exists(Path("./src/test.c"))
+    


### PR DESCRIPTION
- use tempfile and os.replace to create atomic file creation and writing in transactions
- CREATE will create file is already exists but is size 0 or md5 is the same as in filedb
- commands have ignore_list to ignore files like **/README.md
- filedb.json updated when a target file is deleted
- unit test for the ignore list