### PR TITLE
document 'ignore_list' config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ version = "2.0"
 
 # default watch_list is ["**/*.md"]
 watch_list = ["docs/**/*.md"]
+
+# default ignore_list is ["**/README.md"]
+ignore_list = ["docs/**/examples.md"]
 ```
 
 You may add languages as follows:


### PR DESCRIPTION
I stumbled over this, since my initial tests were made by extending an existing `README.md` having to troubleshoot why the file was not picked up by any entangled commands.