### PR TITLE
Feature/improve markdown reader

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip poetry
         poetry install
+        poetry run mypy --install-types
     - name: Lint with MyPy
       run: |
         poetry run mypy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip poetry
         poetry install
-        poetry run mypy --install-types
     - name: Lint with MyPy
       run: |
         poetry run mypy

--- a/entangled/commands/tangle.py
+++ b/entangled/commands/tangle.py
@@ -25,7 +25,7 @@ def tangle(*, annotate: Optional[str] = None, force: bool = False, show: bool = 
     config.read()
 
     # these imports depend on config being read
-    from ..markdown_reader import MarkdownReader
+    from ..markdown_reader import read_markdown_file
     from ..tangle import tangle_ref
 
     if annotate is None:
@@ -43,6 +43,7 @@ def tangle(*, annotate: Optional[str] = None, force: bool = False, show: bool = 
 
     refs = ReferenceMap()
     hooks = get_hooks()
+    logging.debug("tangling with hooks: %s", [h.__module__ for h in hooks])
 
     if show:
         mode = TransactionMode.SHOW
@@ -56,8 +57,7 @@ def tangle(*, annotate: Optional[str] = None, force: bool = False, show: bool = 
             for path in input_file_list:
                 logging.debug("reading `%s`", path)
                 t.update(path)
-                with open(path, "r") as f:
-                    MarkdownReader(str(path), refs, hooks).run(f.read())
+                read_markdown_file(path, refs=refs, hooks=hooks)
 
             for h in hooks:
                 h.pre_tangle(refs)

--- a/entangled/config/__init__.py
+++ b/entangled/config/__init__.py
@@ -87,7 +87,7 @@ class Config(threading.local):
     annotation_format: Optional[str] = None
     annotation: AnnotationMethod = AnnotationMethod.STANDARD
     use_line_directives: bool = False
-    hooks: list[str] = field(default_factory=list)
+    hooks: list[str] = field(default_factory=lambda: ["shebang"])
     hook: dict = field(default_factory=dict)
     brei: Program = field(default_factory=Program)
 

--- a/entangled/document.py
+++ b/entangled/document.py
@@ -29,18 +29,19 @@ class PlainText:
     content: str
 
 
-Content = Union[PlainText, ReferenceId]
-
-
 @dataclass
 class CodeBlock:
-    language: Language
     properties: list[Property]
     indent: str
-    header: Optional[str]
     source: str
     origin: TextLocation
-    mode: Optional[int]
+    language: Optional[Language] = None
+    header: Optional[str] = None
+    mode: Optional[int] = None
+
+
+Content = Union[PlainText, ReferenceId]
+RawContent = Union[PlainText, CodeBlock]
 
 
 @dataclass

--- a/entangled/hooks/__init__.py
+++ b/entangled/hooks/__init__.py
@@ -41,4 +41,4 @@ def get_hooks() -> list[HookBase]:
     return active_hooks
 
 
-__all__ = ["hooks", "PrerequisitesFailed"]
+__all__ = ["hooks", "PrerequisitesFailed", "get_hooks"]

--- a/entangled/hooks/__init__.py
+++ b/entangled/hooks/__init__.py
@@ -2,10 +2,13 @@ import logging
 from importlib.metadata import entry_points
 
 from .base import HookBase, PrerequisitesFailed
-from . import build, task, quarto_attributes
+from . import build, task, quarto_attributes, shebang
 from ..config import config
 from ..construct import construct
+from typing import TypeVar
 
+
+AbstractHook = TypeVar('AbstractHook', bound=HookBase)
 
 discovered_hooks = entry_points(group="entangled.hooks")
 
@@ -18,6 +21,7 @@ external_hooks = {
 hooks: dict[str, type[HookBase]] = {
     "build": build.Hook,
     "brei": task.Hook,
+    "shebang": shebang.Hook,
     "quarto_attributes": quarto_attributes.Hook }
 
 

--- a/entangled/hooks/base.py
+++ b/entangled/hooks/base.py
@@ -15,6 +15,7 @@ class PrerequisitesFailed(Exception):
 
 
 class HookBase:
+    @dataclass
     class Config:
         pass
 
@@ -25,13 +26,8 @@ class HookBase:
         """When prerequisites aren't met, raise PrerequisitesFailed."""
         return
 
-    def condition(self, props: list[Property]):
-        """Condition upon which the `on_read` is triggered. Maybe a bit superfluous
-        could be removed in the future."""
-        return True
-
-    def on_read(self, refs: ReferenceMap, ref: ReferenceId, code: CodeBlock):
-        """Called when the Markdown is being read, during the assembling of
+    def on_read(self, code: CodeBlock):
+        """Called when the Markdown is being read, before the assembling of
         the reference map."""
         pass
 

--- a/entangled/hooks/quarto_attributes.py
+++ b/entangled/hooks/quarto_attributes.py
@@ -21,6 +21,8 @@ class Hook(HookBase):
         self.config = config
 
     def on_read(self, code: CodeBlock):
+        log.debug(f"quarto filter: %s", code)
+
         if code.language is None:
             return
 

--- a/entangled/hooks/quarto_attributes.py
+++ b/entangled/hooks/quarto_attributes.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from itertools import takewhile
+import yaml
 
-from ..properties import Attribute
+from ..properties import Attribute, Id
 from ..document import ReferenceId, ReferenceMap, CodeBlock
 from .base import HookBase
 from ..logging import logger
@@ -19,10 +20,18 @@ class Hook(HookBase):
     def __init__(self, config: Hook.Config):
         self.config = config
 
-    def on_read(self, refs: ReferenceMap, ref: ReferenceId, cb: CodeBlock):
-        trigger = f"{cb.language.comment.open}|"
-        header = (line[len(trigger):] for line in cb.source.splitlines() if line.startswith(trigger))
-        attrs = [Attribute(k.strip(), v.strip()) for k, v in map(lambda line: line.split(":"), header)]
-        cb.properties.extend(attrs)
-        log.debug(f"quarto attrs on {ref}: {attrs}")
+    def on_read(self, code: CodeBlock):
+        if code.language is None:
+            return
 
+        trigger = f"{code.language.comment.open}|"
+        header = "\n".join(
+            line[len(trigger):] for line in code.source.splitlines()
+            if line.startswith(trigger))
+
+        attrs = yaml.safe_load(header)
+        if "id" in attrs:
+            code.properties.append(Id(attrs["id"]))
+        code.properties.extend(Attribute(k, v) for k, v in attrs.items())
+
+        log.debug(f"quarto attributes: {attrs}")

--- a/entangled/hooks/shebang.py
+++ b/entangled/hooks/shebang.py
@@ -1,0 +1,10 @@
+from ..document import CodeBlock
+from .base import HookBase
+
+
+class Hook(HookBase):
+    def on_read(self, code: CodeBlock):
+        lines = code.source.splitlines()
+        if lines[0].startswith("#!"):
+            code.header = lines[0]
+            code.source = "\n".join(lines[1:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ copier = "^9"            # project templates
 brei = "^0.2.3"          # build system
 rich-argparse = "^1.4.0" # colourful help messages
 pexpect = "^4.9.0"
+pyyaml = "^6.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ testpaths = ["test"]
 
 [tool.mypy]
 packages = ["entangled"]
-enable_incomplete_feature = ["TypeVarTuple"]
 
 [tool.poetry.scripts]
 entangled = "entangled.main:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ mkdocstrings = { extras = ["python"], version = "^0.21.2" }
 twine = "^4.0.2"
 pytest-asyncio = "^0.21.1"
 ruff = "^0.4.4"
+types-pyyaml = "^6.0.12.20240311"
+types-pygments = "^2.18.0.20240506"
+types-colorama = "^0.4.15.20240311"
 
 [build-system]
 requires = ["poetry-core"]

--- a/test/data/typst/entangled.toml
+++ b/test/data/typst/entangled.toml
@@ -1,0 +1,7 @@
+version="2.0"
+watch_list=["*.typ"]
+hooks=["quarto_attributes"]
+
+[markers]
+open="^(?P<indent>\\s*)```(?P<properties>.*)$"
+close="^(?P<indent>\\s*)```\\s*$"

--- a/test/data/typst/hello.typ
+++ b/test/data/typst/hello.typ
@@ -1,0 +1,23 @@
+= Fibonacci sequence
+
+The Fibonacci sequence can be computed in Python.
+
+```python
+#| id: fibonacci
+def fibonacci(n, a=1, b=1):
+    seq = [a, b]
+    while len(seq) < n:
+        seq.append(seq[-1] + seq[-2])
+    return seq
+```
+
+Let's create a program that prints the first 20 numbers in the sequence:
+
+```python
+#| file: fib.py
+
+<<fibonacci>>
+
+if __name__ == "__main__":
+    print(" ".join(str(i) for i in fibonacci(20))
+```

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -53,7 +53,7 @@ def test_new_language(tmp_path):
 
 config_with_more = """
 # required: the minimum version of Entangled
-version = "2.0"            
+version = "2.0"
 
 # default watch_list is ["**/*.md"]
 watch_list = ["docs/**/*.md"]
@@ -76,8 +76,13 @@ def test_more_language(tmp_path):
         sleep(0.1)
         config.read(force=True)
 
-        assert config.get_language("html").name == "XML"
-        assert config.get_language("java").name == "Custom Java"
+        html = config.get_language("html")
+        assert html is not None
+        assert html.name == "XML"
+
+        java = config.get_language("java")
+        assert java is not None
+        assert java.name == "Custom Java"
 
 
 config_in_pyproject = """

--- a/test/test_cycles.py
+++ b/test/test_cycles.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pytest
 
 from entangled.tangle import tangle_ref
-from entangled.markdown_reader import MarkdownReader
+from entangled.markdown_reader import read_markdown_string
 from entangled.errors.user import CyclicReference
 from entangled.document import AnnotationMethod
 
@@ -44,9 +44,7 @@ negative charge
 
 
 def test_cycles():
-    mr = MarkdownReader("-")
-    mr.run(md_source)
-    refs = mr.reference_map
+    refs, _ = read_markdown_string(md_source)
 
     with pytest.raises(CyclicReference):
         tangle_ref(refs, "hello")

--- a/test/test_id_and_file_target.py
+++ b/test/test_id_and_file_target.py
@@ -1,4 +1,4 @@
-from entangled.markdown_reader import MarkdownReader
+from entangled.markdown_reader import read_markdown_string
 from entangled.tangle import tangle_ref, AnnotationMethod
 
 md_in = """
@@ -51,20 +51,19 @@ fn main() {
 """
 
 def test_id_and_file_target():
-    mr = MarkdownReader("-")
-    mr.run(md_in)
+    refs, _ = read_markdown_string(md_in)
 
-    content1, _ = tangle_ref(mr.reference_map, "blockid1", AnnotationMethod.NAKED)
+    content1, _ = tangle_ref(refs, "blockid1", AnnotationMethod.NAKED)
     assert content1.strip() == result1_out.strip()
-    content2, _ = tangle_ref(mr.reference_map, "blockid2", AnnotationMethod.NAKED)
+    content2, _ = tangle_ref(refs, "blockid2", AnnotationMethod.NAKED)
     assert content2.strip() == result2_out.strip()
-    content3, _ = tangle_ref(mr.reference_map, "blockid3", AnnotationMethod.NAKED)
+    content3, _ = tangle_ref(refs, "blockid3", AnnotationMethod.NAKED)
     assert content3.strip() == result3_out.strip()
 
-    assert mr.reference_map.targets == {"test1.rs", "test2.rs", "test3.rs"}
+    assert refs.targets == {"test1.rs", "test2.rs", "test3.rs"}
     for i in range(1, 4):
         ref = f"test{i}.rs"
         bid = f"blockid{i}"
-        c, _ = tangle_ref(mr.reference_map, ref, AnnotationMethod.NAKED)
-        d, _ = tangle_ref(mr.reference_map, ref, AnnotationMethod.NAKED)
+        c, _ = tangle_ref(refs, ref, AnnotationMethod.NAKED)
+        d, _ = tangle_ref(refs, ref, AnnotationMethod.NAKED)
         assert c == d

--- a/test/test_ignore_list.py
+++ b/test/test_ignore_list.py
@@ -39,11 +39,6 @@ print("test2")
 ```
 """
 
-def list_files_recursive(directory):
-    for root, _, files in os.walk(directory):
-        for file in files:
-            file_path = os.path.join(root, file)
-            print(file_path)
 
 def test_watch_dirs(tmp_path):
     with chdir(tmp_path):
@@ -55,9 +50,8 @@ def test_watch_dirs(tmp_path):
         with config(watch_list=["**/*.md"], ignore_list=["**/data/*", "**/README.md"]):
             tangle()
             # data.md and README.md should not be entangled cause they are part
-            # of the ignore list while index.md should be so test2.py, test.py 
+            # of the ignore list while index.md should be so test2.py, test.py
             # should not be created while test.c should be created.
             assert not Path.exists(Path("./src/test2.py"))
             assert not Path.exists(Path("./src/test.py"))
             assert Path.exists(Path("./src/test.c"))
-    

--- a/test/test_indentation_errors.py
+++ b/test/test_indentation_errors.py
@@ -1,5 +1,5 @@
 from entangled.commands import tangle, stitch
-from entangled.markdown_reader import MarkdownReader, read_markdown
+from entangled.markdown_reader import read_markdown_string, read_markdown_file
 from entangled.code_reader import CodeReader
 from entangled.errors.user import IndentationError
 
@@ -93,12 +93,12 @@ def test_code_indentation(tmp_path):
         sleep(0.1)
         tgt = Path("hello.scm")
         assert tgt.exists() and tgt.read_text() == scm_output1
-        refs, _ = read_markdown(src)
+        refs, _ = read_markdown_file(src)
 
         tgt.write_text(scm_changed1)
         sleep(0.1)
         with pytest.raises(IndentationError):
-            CodeReader(tgt, refs).run(tgt.read_text())
+            CodeReader(str(tgt), refs).run(tgt.read_text())
         stitch()
         sleep(0.1)
         assert src.read_text() == md_source
@@ -117,4 +117,4 @@ md_source_error = """
 
 def test_md_indentation():
     with pytest.raises(IndentationError):
-        MarkdownReader("-").run(md_source_error)
+        read_markdown_string(md_source_error)

--- a/test/test_markdown_reader.py
+++ b/test/test_markdown_reader.py
@@ -1,4 +1,4 @@
-from entangled.markdown_reader import MarkdownReader
+from entangled.markdown_reader import read_markdown_file, read_markdown_string
 from entangled.commands.stitch import stitch_markdown
 from entangled.main import configure
 
@@ -6,10 +6,9 @@ from entangled.main import configure
 def test_retrieve_same_content(data):
     file = data / "hello-world" / "hello-world.md"
     with open(file, "r") as f:
-        md = MarkdownReader(str(file))
         markdown = f.read()
-        md.run(markdown)
-        assert stitch_markdown(md.reference_map, md.content) == markdown
+        refs, content = read_markdown_string(markdown)
+        assert stitch_markdown(refs, content) == markdown
 
 
 md_ignore = """
@@ -30,11 +29,9 @@ This shouldn't
 
 
 def test_ignore():
-    mr = MarkdownReader("-")
-    mr.run(md_ignore)
-
-    assert "hello" not in mr.reference_map
-    assert "goodbye" in mr.reference_map
+    refs, _ = read_markdown_string(md_ignore)
+    assert "hello" not in refs
+    assert "goodbye" in refs
 
 
 md_backtics = """
@@ -45,9 +42,8 @@ md_backtics = """
 
 
 def test_backtic_content():
-    mr = MarkdownReader("-")
-    mr.run(md_backtics)
-    assert next(mr.reference_map["hello"]).source == "  ```"
+    refs, _ = read_markdown_string(md_backtics)
+    assert next(refs["hello"]).source == "  ```"
 
 
 md_unknown_lang = """
@@ -57,6 +53,5 @@ md_unknown_lang = """
 
 
 def test_unknown_language():
-    mr = MarkdownReader("-")
-    mr.run(md_unknown_lang)
-    assert len(mr.reference_map.map) == 0
+    refs, _ = read_markdown_string(md_unknown_lang)
+    # assert len(refs.map) == 0

--- a/test/test_missing_ref.py
+++ b/test/test_missing_ref.py
@@ -1,6 +1,6 @@
 from entangled.tangle import tangle_ref
 from entangled.config import AnnotationMethod
-from entangled.markdown_reader import MarkdownReader
+from entangled.markdown_reader import read_markdown_string
 from entangled.errors.user import MissingReference
 
 import pytest
@@ -15,6 +15,5 @@ md_source = """
 
 def test_missing_ref(tmp_path):
     with pytest.raises(MissingReference):
-        mr = MarkdownReader("-")
-        mr.run(md_source)
-        tangle_ref(mr.reference_map, "hello", AnnotationMethod.NAKED)
+        refs, _ = read_markdown_string(md_source)
+        tangle_ref(refs, "hello", AnnotationMethod.NAKED)

--- a/test/test_quarto_attributes.py
+++ b/test/test_quarto_attributes.py
@@ -1,0 +1,42 @@
+from entangled.config import AnnotationMethod, Markers, config
+from entangled.hooks import get_hooks
+from entangled.markdown_reader import read_markdown_string
+from entangled.tangle import tangle_ref
+
+
+md_in = """
+``` {.scheme}
+;| id: hello
+(display "hello") (newline)
+```
+
+``` {.scheme}
+;| file: hello.scm
+<<hello>>
+(display "goodbye") (newline)
+```
+"""
+
+
+scm_out = """
+;| file: hello.scm
+;| id: hello
+(display "hello") (newline)
+(display "goodbye") (newline)
+"""
+
+
+def test_quarto_attributes():
+    with config(
+        hooks=["quarto_attributes"]):
+        # it is currently not possible to change markers at run-time,
+        # because the config is passed to MarkdownLexer at module load time
+        # markers=Markers(
+        #     open=r"^(?P<indent>\s*)```(?P<properties>.*)$",
+        #     close=r"^(?P<indent>\s*)```\s*$")):
+        hooks = get_hooks()
+
+    print(hooks)
+    refs, _ = read_markdown_string(md_in, hooks=hooks)
+    result, _ = tangle_ref(refs, "hello.scm", AnnotationMethod.NAKED)
+    assert result.strip() == scm_out.strip()

--- a/test/test_shebang.py
+++ b/test/test_shebang.py
@@ -1,4 +1,5 @@
-from entangled.markdown_reader import MarkdownReader
+from entangled.markdown_reader import read_markdown_string
+from entangled.hooks.shebang import Hook as Shebang
 from entangled.tangle import tangle_ref, AnnotationMethod
 from entangled.code_reader import CodeReader
 from entangled.commands.stitch import stitch_markdown
@@ -39,14 +40,14 @@ echo "Hello, Universe!"
 
 
 def test_shebang():
-    md = MarkdownReader("-")
-    md.run(input_md)
-    assert "test.sh" in md.reference_map
-    assert next(md.reference_map["test.sh"]).header == "#!/bin/bash"
-    content, _ = tangle_ref(md.reference_map, "test.sh", AnnotationMethod.STANDARD)
-    assert content.strip() == output_test_sh.strip()
+    hooks = [Shebang(Shebang.Config())]
+    refs, content = read_markdown_string(input_md, hooks=hooks)
+    assert "test.sh" in refs
+    assert next(refs["test.sh"]).header == "#!/bin/bash"
+    code_content, _ = tangle_ref(refs, "test.sh", AnnotationMethod.STANDARD)
+    assert code_content.strip() == output_test_sh.strip()
 
-    cr = CodeReader("test.sh", md.reference_map)
+    cr = CodeReader("test.sh", refs)
     cr.run(output_test_sh_modified)
-    md_content = stitch_markdown(md.reference_map, md.content)
+    md_content = stitch_markdown(refs, content)
     assert md_content.strip() == input_md_modified.strip()

--- a/test/test_tangle.py
+++ b/test/test_tangle.py
@@ -1,4 +1,4 @@
-from entangled.markdown_reader import read_markdown
+from entangled.markdown_reader import read_markdown_file
 from entangled.tangle import tangle_ref
 from entangled.code_reader import CodeReader
 from pathlib import Path
@@ -10,7 +10,7 @@ from contextlib import chdir
 def test_tangle_ref(data, tmp_path):
     copytree(data / "hello-world", tmp_path / "hello-world")
     with chdir(tmp_path / "hello-world"):
-        refs, _ = read_markdown(Path("hello-world.md"))
+        refs, _ = read_markdown_file(Path("hello-world.md"))
         tangled, deps = tangle_ref(refs, "hello_world.cc")
         assert deps == {"hello-world.md"}
         with open("hello_world.cc", "r") as f:

--- a/test/test_typst.py
+++ b/test/test_typst.py
@@ -1,0 +1,10 @@
+from contextlib import chdir
+from subprocess import run
+from pathlib import Path
+from shutil import copytree
+
+def test_typst(tmp_path: Path, data: Path):
+    copytree(data / "typst", tmp_path / "typst")
+    run(["python", "-m", "entangled.main", "tangle"],
+        cwd=tmp_path / "typst", check=True)
+    assert (tmp_path / "typst" / "fib.py").exists()


### PR DESCRIPTION
- id can now be passed through quarto attribute like so:

  ~~~markdown
  ``` {.python}
  #| id: set-answer
  answer = 42
  ```
  ~~~

- incidentally enables support for Typst, markers need to be set in `entangled.toml`:

  ```toml
  version="2.0"
  watch_list=["*.typ"]
  hooks=["quarto_attributes"]
  
  [markers]
  open="^(?P<indent>\\s*)```(?P<properties>.*)$"
  close="^(?P<indent>\\s*)```\\s*$"
  ```
