### PR TITLE
Add yaml to the list of languages

### DIFF
--- a/entangled/config/language.py
+++ b/entangled/config/language.py
@@ -43,7 +43,7 @@ languages = [
     Language("Make", ["make", "makefile"], Comment("#")),
     Language("Gnuplot", ["gnuplot"], Comment("#")),
     Language("TOML", ["toml"], Comment("#")),
-    Language("Yaml", ["yaml"], Comment("#")),
+    Language("YAML", ["yaml"], Comment("#")),
     Language("F#", ["fsharp"], Comment("//")),
     Language("Javascript", ["javascript", "js", "ecma"], Comment("//")),
     Language("Go", ["go", "golang"], Comment("//")),

--- a/entangled/config/language.py
+++ b/entangled/config/language.py
@@ -43,6 +43,7 @@ languages = [
     Language("Make", ["make", "makefile"], Comment("#")),
     Language("Gnuplot", ["gnuplot"], Comment("#")),
     Language("TOML", ["toml"], Comment("#")),
+    Language("Yaml", ["yaml"], Comment("#")),
     Language("F#", ["fsharp"], Comment("//")),
     Language("Javascript", ["javascript", "js", "ecma"], Comment("//")),
     Language("Go", ["go", "golang"], Comment("//")),


### PR DESCRIPTION
Trying to tangle a `yaml` file fails because the yaml format is unknown. Add it, it's common and it supports comments.