### PR TITLE
Don't crash when a tracked file is missing (#88)

### DIFF
--- a/entangled/io/filedb.py
+++ b/entangled/io/filedb.py
@@ -50,8 +50,11 @@ class FileDB(Struct):
         return {Path(p) for p in self.targets}
 
     def changed_files(self, fs: AbstractFileCache) -> Generator[Path]:
+        # A tracked file that no longer exists (e.g. a source that was moved or
+        # deleted) counts as changed. Without this guard `fs[Path(p)]` would
+        # raise `FileNotFoundError` and crash, see issue #88.
         return (Path(p) for p, known_stat in self.files.items()
-                if fs[Path(p)].stat != known_stat)
+                if Path(p) not in fs or fs[Path(p)].stat != known_stat)
 
     def create_target(self, fs: AbstractFileCache, path: Path):
         if path.is_absolute():

--- a/test/io/test_filedb.py
+++ b/test/io/test_filedb.py
@@ -50,3 +50,24 @@ def test_filedb(example_files: Path):
             assert list(db.changed_files(fs)) == [Path("d")]
             db.update(fs, Path("d"))
             assert list(db.changed_files(fs)) == []
+
+
+def test_changed_files_missing(tmp_path: Path):
+    """Regression test for issue #88: a tracked file that no longer exists on
+    disk (e.g. a source markdown file that was moved or renamed) should be
+    reported as changed rather than crashing with `FileNotFoundError`."""
+    with chdir(tmp_path):
+        with open("source", "w") as f:
+            _ = f.write("hello")
+
+        fs = FileCache()
+        with filedb(fs=fs) as db:
+            db.update(fs, Path("source"))
+            assert list(db.changed_files(fs)) == []
+
+        # the file is moved/removed while still tracked in the db
+        Path("source").unlink()
+        fs.reset()
+
+        with filedb(fs=fs) as db:
+            assert list(db.changed_files(fs)) == [Path("source")]


### PR DESCRIPTION
Moving or renaming a source markdown file left a stale entry in the filedb pointing at a path that no longer exists. `FileDB.changed_files` then called `fs[Path(p)]` on it, raising `FileNotFoundError` and crashing `sync`/`watch`.

Treat a tracked file that is no longer on disk as changed, so a moved or deleted source surfaces as a change (triggering a re-tangle) instead of throwing.

Adds a regression test.

Notable finding: this issue and #96 are complementary. With only the #88 fix, a rename no longer crashes but then trips the #96 false-positive conflict (the annotation comment changes from <<test.md…>> to <<not-test.md…>> while the renamed source is older). I verified that with both fixes applied, a source rename works fully cleanly (test.c correctly re-references not-test.md, exit 0). So once both PRs land, "move a source file" works end-to-end. The two branches are independent, so they can be reviewed/merged in either order.